### PR TITLE
feat: implement the egg-rpc plugin

### DIFF
--- a/.autod.conf.js
+++ b/.autod.conf.js
@@ -1,0 +1,26 @@
+'use strict';
+
+module.exports = {
+  write: true,
+  prefix: '^',
+  plugin: 'autod-egg',
+  test: [
+    'test',
+    'benchmark',
+  ],
+  devdep: [
+    'egg',
+    'egg-bin',
+    'autod',
+    'autod-egg',
+    'eslint',
+    'eslint-config-egg',
+    'egg-rpc-generator',
+    'webstorm-disable-index',
+  ],
+  exclude: [
+    './test/fixtures',
+    './docs',
+    './coverage',
+  ],
+};

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,7 @@
+test/fixtures
+coverage
+examples/**/app/public
+logs
+run
+zookeeper-3.4.6/
+coverage

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "eslint-config-egg"
+}

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+<!--
+Thank you for your pull request. Please review below requirements.
+Bug fixes and new features should include tests and possibly benchmarks.
+Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
+
+感谢您贡献代码。请确认下列 checklist 的完成情况。
+Bug 修复和新功能必须包含测试，必要时请附上性能测试。
+Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
+-->
+
+##### Checklist
+<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
+
+- [ ] `npm test` passes
+- [ ] tests and/or benchmarks are included
+- [ ] documentation is changed or added
+- [ ] commit message follows commit guidelines
+
+##### Affected core subsystem(s)
+<!-- Provide affected core subsystem(s). -->
+
+
+##### Description of change
+<!-- Provide a description of the change below this comment. -->

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,14 @@ typings/
 
 # next.js build output
 .next
+
+.*
+!.github
+!.eslintignore
+!.eslintrc
+!.gitignore
+!.travis.yml
+!.autod.conf.js
+*.bin
+
+run

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+sudo: false
+language: node_js
+node_js:
+  - '8'
+  - '10'
+before_install:
+  - 'wget https://archive.apache.org/dist/zookeeper/zookeeper-3.4.6/zookeeper-3.4.6.tar.gz'
+  - 'tar xf zookeeper-3.4.6.tar.gz'
+  - 'mv zookeeper-3.4.6/conf/zoo_sample.cfg zookeeper-3.4.6/conf/zoo.cfg'
+  - './zookeeper-3.4.6/bin/zkServer.sh start'
+install:
+  - npm i npminstall && npminstall --registry=https://registry.npm.taobao.org
+script:
+  - npm run ci
+after_script:
+  - npminstall codecov && codecov

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
-MIT License
+The MIT License (MIT)
 
-Copyright (c) 2018 egg
+Copyright (c) 2018 eggjs core team and other contributors.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,2 +1,257 @@
 # egg-rpc
-rpc plugin for eggjs
+
+[![NPM version][npm-image]][npm-url]
+[![build status][travis-image]][travis-url]
+[![Test coverage][codecov-image]][codecov-url]
+[![David deps][david-image]][david-url]
+[![Known Vulnerabilities][snyk-image]][snyk-url]
+[![npm download][download-image]][download-url]
+
+[npm-image]: https://img.shields.io/npm/v/egg-rpc-base.svg?style=flat-square
+[npm-url]: https://npmjs.org/package/egg-rpc-base
+[travis-image]: https://img.shields.io/travis/eggjs/egg-rpc.svg?style=flat-square
+[travis-url]: https://travis-ci.org/eggjs/egg-rpc
+[codecov-image]: https://img.shields.io/codecov/c/github/eggjs/egg-rpc.svg?style=flat-square
+[codecov-url]: https://codecov.io/github/eggjs/egg-rpc?branch=master
+[david-image]: https://img.shields.io/david/eggjs/egg-rpc.svg?style=flat-square
+[david-url]: https://david-dm.org/eggjs/egg-rpc
+[snyk-image]: https://snyk.io/test/npm/egg-rpc-base/badge.svg?style=flat-square
+[snyk-url]: https://snyk.io/test/npm/egg-rpc-base
+[download-image]: https://img.shields.io/npm/dm/egg-rpc-base.svg?style=flat-square
+[download-url]: https://npmjs.org/package/egg-rpc-base
+
+egg-rpc plugin for egg framework
+
+## Install
+
+```bash
+$ npm i egg-rpc-base --save
+```
+
+## Usage
+
+### Enable the plugin
+
+Change `${app_root}/config/plugin.js` to enable egg-rpc plugin:
+
+```js
+exports.rpc = {
+  enable: true,
+  package: 'egg-rpc-base',
+};
+```
+
+### RPC Service Discovery
+
+By default, We use zookeeper for service discovery. Therefore you need to configure the zk address:
+
+```js
+// ${app_root}/config/config.${env}.js
+config.rpc = {
+  registry: {
+    address: '127.0.0.1:2181', // configure your real zk address
+  },
+};
+```
+
+We plan to provide more implementations of service discovery. And also you can implement it by yourself, you can follow this [article](https://github.com/eggjs/egg-sofa-rpc/wiki/%E8%87%AA%E5%AE%9A%E4%B9%89%E6%9C%8D%E5%8A%A1%E5%8F%91%E7%8E%B0%E5%AE%9E%E7%8E%B0)
+
+### RPC Client
+
+By using the plugin, you can call rpc services provided by other system.
+
+#### 1. Get the RPC Interface Definition
+
+We use [protobuf interface definition lanaguge](https://developers.google.com/protocol-buffers/docs/proto3) to describe the RPC service. So you need to get the \*.proto files and put them into `${app_root}/proto` folder
+
+#### 2. Global RPC Client Configuration
+
+Configure RPC Client information in ${app_root}/config/config.{env}.js:
+
+```js
+// ${app_root}config/config.${env}.js
+exports.rpc = {
+  client: {
+    responseTimeout: 3000,
+  },
+};
+```
+
+- `responseTimeout`(optional): RPC timeout in milliseconds, default value is 3000
+
+#### 3. Configure the Interface in proxy.js
+
+`${app_root}/config/proxy.js` is a very important config file for rpc client, you should configure the services you needed, then executing the `egg-rpc-generator` tool to generate the proxy files.
+
+Let's see a simple example of proxy.js. It declare a interface named: `org.eggjs.rpc.test.ProtoService` provided by `rpc-demo` application
+
+```js
+'use strict';
+
+module.exports = {
+  services: [{
+    appName: 'rpc-demo',
+    api: {
+      ProtoService: 'org.eggjs.rpc.test.ProtoService',
+    },
+  }],
+};
+```
+
+Refer this [acticle](https://github.com/eggjs/egg-sofa-rpc/wiki/RPC-%E4%BB%A3%E7%90%86%EF%BC%88Proxy%EF%BC%89%E9%85%8D%E7%BD%AE) for more details
+
+#### 4. Generate the Proxy
+
+Run `egg-rpc-generator` to generate the proxy files. After running success, it will generate a file: `ProtoService.js` under `${app_root}/app/proxy`
+
+```bash
+$ egg-rpc-generator
+
+[EggRpcGenerator] framework: /egg-rpc-demo/node_modules/egg, baseDir: /egg-rpc-demo
+[ProtoRPCPlugin] found "org.eggjs.rpc.test.ProtoService" in proto file
+[ProtoRPCPlugin] save all proto info into "/egg-rpc-demo/run/proto.json"
+```
+
+#### 5. Call the Service
+
+You can call the RPC service by using `ctx.proxy.proxyName`. The proxyName is `key` value of api object you configure in proxy.js. In our example, it's ProtoService, and proxyName using lower camelcase, so it's `ctx.proxy.protoService`
+
+```js
+'use strict';
+
+const Controller = require('egg').Controller;
+
+class HomeController extends Controller {
+  async index() {
+    const { ctx } = this;
+    const res = await ctx.proxy.protoService.echoObj({
+      name: 'gxcsoccer',
+	    group: 'A',
+    });
+    ctx.body = res;
+  }
+}
+
+module.exports = HomeController;
+```
+
+As above, you can call remote service as a local method.
+
+### RPC Server
+
+By using the plugin, you also can publish your own RPC service to other system.
+
+#### 1. Define the RPC Interface
+
+Writing the \*.proto files, and put them into `${app_root}/proto` folder
+
+```
+# ProtoService.proto
+syntax = "proto3";
+
+package org.eggjs.rpc.test;
+option java_multiple_files = true; // 可选
+option java_outer_classname = "ProtoServiceModels"; // 可选
+
+service ProtoService {
+    rpc echoObj (EchoRequest) returns (EchoResponse) {}
+}
+
+message EchoRequest {
+    string name = 1;
+    Group group = 2;
+}
+
+message EchoResponse {
+    int32 code = 1;
+    string message = 2;
+}
+
+enum Group {
+    A = 0;
+    B = 1;
+}
+```
+
+#### 2. Global RPC Server Configuration
+
+Configure RPC Server information in ${app_root}/config/config.{env}.js:
+
+```js
+module.exports = {
+	rpc: {
+    server: {
+      namespace: 'org.eggjs.rpc.test',
+    },
+	},
+},
+```
+
+- `namespace`(required): the default namespace of all rpc service
+- `selfPublish`(optional): whether every node process publish service independent, default is true
+- `port`(optional): the TCP port will be listen on
+- `maxIdleTime`(optional): server will disconnect the socket if idle for long time
+- `responseTimeout`(optional): Number of milliseconds to wait for a response to begin arriving back from the remote system after sending a request
+- `codecType`(optional): recommended serialization method，default is protobuf
+
+#### 3. Implemenation the RPC Interface
+
+Put your implementation code under `${app_root}/app/rpc` folder
+
+```js
+// ${app_root}/app/rpc/ProtoService.js
+exports.echoObj = async function(req) {
+  return {
+    code: 200,
+    message: 'hello ' + req.name + ', you are in ' + req.group,
+  };
+};
+```
+
+#### 4. RPC Unittest in Eggjs
+
+```js
+'use strict';
+
+const mm = require('egg-mock');
+
+describe('test/index.test.js', () => {
+  let app;
+  before(async function() {
+    app = mm.app({
+      baseDir: 'apps/rpcserver',
+    });
+    await app.ready();
+  });
+  after(async function() {
+    await app.close();
+  });
+
+  it('should invoke HelloService', done => {
+    app.rpcRequest('org.eggjs.rpc.test.HelloService')
+      .invoke('hello')
+      .send([ 'gxcsoccer' ])
+      .expect('hello gxcsoccer', done);
+  });
+});
+```
+
+For more details of `app.rpcRequest`, you can refer to this [acticle](https://github.com/eggjs/egg-sofa-rpc/wiki/%E5%8D%95%E5%85%83%E6%B5%8B%E8%AF%95-RPC-%E6%9C%8D%E5%8A%A1%E7%9A%84%E6%96%B9%E6%B3%95)
+
+## Docs
+
+- [RPC in Nodejs Part One](https://github.com/alipay/sofa-rpc-node/wiki/%E8%81%8A%E8%81%8A-Nodejs-RPC%EF%BC%88%E4%B8%80%EF%BC%89)
+- [Cross-Language Interoperability between Eggjs & SOFA](https://github.com/eggjs/egg-sofa-rpc/wiki/Eggjs-%E5%92%8C-SOFA-%E7%9A%84%E8%B7%A8%E8%AF%AD%E8%A8%80%E4%BA%92%E8%B0%83)
+- [Custom Service Discovery in Eggjs](https://github.com/eggjs/egg-sofa-rpc/wiki/%E8%87%AA%E5%AE%9A%E4%B9%89%E6%9C%8D%E5%8A%A1%E5%8F%91%E7%8E%B0%E5%AE%9E%E7%8E%B0)
+- [RPC Proxy Configuration in Eggjs](https://github.com/eggjs/egg-sofa-rpc/wiki/RPC-%E4%BB%A3%E7%90%86%EF%BC%88Proxy%EF%BC%89%E9%85%8D%E7%BD%AE)
+- [RPC Unittest in Eggjs](https://github.com/eggjs/egg-sofa-rpc/wiki/%E5%8D%95%E5%85%83%E6%B5%8B%E8%AF%95-RPC-%E6%9C%8D%E5%8A%A1%E7%9A%84%E6%96%B9%E6%B3%95)
+
+## How to Contribute
+
+Please let us know how can we help. Do check out [issues](https://github.com/eggjs/egg/issues) for bug reports or suggestions first.
+
+To become a contributor, please follow our [contributing guide](https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md).
+
+## License
+
+[MIT](LICENSE)

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -1,0 +1,259 @@
+# egg-rpc
+
+[![NPM version][npm-image]][npm-url]
+[![build status][travis-image]][travis-url]
+[![Test coverage][codecov-image]][codecov-url]
+[![David deps][david-image]][david-url]
+[![Known Vulnerabilities][snyk-image]][snyk-url]
+[![npm download][download-image]][download-url]
+
+[npm-image]: https://img.shields.io/npm/v/egg-rpc-base.svg?style=flat-square
+[npm-url]: https://npmjs.org/package/egg-rpc-base
+[travis-image]: https://img.shields.io/travis/eggjs/egg-rpc.svg?style=flat-square
+[travis-url]: https://travis-ci.org/eggjs/egg-rpc
+[codecov-image]: https://img.shields.io/codecov/c/github/eggjs/egg-rpc.svg?style=flat-square
+[codecov-url]: https://codecov.io/github/eggjs/egg-rpc?branch=master
+[david-image]: https://img.shields.io/david/eggjs/egg-rpc.svg?style=flat-square
+[david-url]: https://david-dm.org/eggjs/egg-rpc
+[snyk-image]: https://snyk.io/test/npm/egg-rpc-base/badge.svg?style=flat-square
+[snyk-url]: https://snyk.io/test/npm/egg-rpc-base
+[download-image]: https://img.shields.io/npm/dm/egg-rpc-base.svg?style=flat-square
+[download-url]: https://npmjs.org/package/egg-rpc-base
+
+egg-rpc 插件是为 egg 提供调用和发布 RPC 服务的能力
+
+## 安装
+
+```bash
+$ npm i egg-rpc-base --save
+```
+
+## 用法
+
+### 开启插件
+
+通过 `${app_root}/config/plugin.js` 配置启动 egg-rpc 插件:
+
+```js
+exports.rpc = {
+  enable: true,
+  package: 'egg-rpc-base',
+};
+```
+
+### RPC 服务发现
+
+默认的服务发现依赖于 `zookeeper`，所以你需要配置一个 zk 的地址
+
+```js
+// ${app_root}/config/config.${env}.js
+config.rpc = {
+  registry: {
+    address: '127.0.0.1:2181', // 根据实际情况配置
+  },
+};
+```
+
+后续我们还会提供更多的服务发现实现，你也可以根据自己的需求实现自己的 registry，详细可以参考：[自定义服务发现实现](https://github.com/eggjs/egg-sofa-rpc/wiki/%E8%87%AA%E5%AE%9A%E4%B9%89%E6%9C%8D%E5%8A%A1%E5%8F%91%E7%8E%B0%E5%AE%9E%E7%8E%B0)
+
+### RPC 客户端
+
+该插件提供调用其他系统暴露的 rpc 接口的能力
+
+#### 1. 获取接口定义
+
+以 protobuf 为例，将 \*.proto 文件放置到 `${app_root}/proto` 目录下
+
+#### 2. 全局配置
+
+可以在 `${app_root}/config/config.${env}.js` 做一些全局性的配置
+
+```js
+// ${app_root}config/config.${env}.js
+exports.rpc = {
+  client: {
+    responseTimeout: 3000,
+  },
+};
+```
+
+- `responseTimeout`(可选): RPC 的超时时长，默认为 3 秒
+
+#### 3. 申明要调用的接口
+
+RPC 客户端还有一个重要的配置文件是：`${app_root}/config/proxy.js`，你需要把你调用的服务配置到里面，然后通过 `egg-rpc-generator` 工具帮你生成本地调用代码。
+
+让我们看一个最简单的配置，它的基本含义是：我需要调用 `rpc-demo` 应用暴露的 `org.eggjs.rpc.test.ProtoService` 这个服务。
+
+```js
+'use strict';
+
+module.exports = {
+  services: [{
+    appName: 'rpc-demo',
+    api: {
+      ProtoService: 'org.eggjs.rpc.test.ProtoService',
+    },
+  }],
+};
+```
+
+详细的配置可以参考 [RPC 代理（Proxy）配置](https://github.com/eggjs/egg-sofa-rpc/wiki/RPC-%E4%BB%A3%E7%90%86%EF%BC%88Proxy%EF%BC%89%E9%85%8D%E7%BD%AE)
+
+#### 4. 生成本地调用代理
+
+配置好了，运行 `egg-rpc-generator` 生成本地调用代理文件。运行成功后，会在 `${app_root}/app/proxy` 目录下生成一个 `ProtoSerivce.js` 文件
+
+```bash
+$ egg-rpc-generator
+
+[EggRpcGenerator] framework: /egg-rpc-demo/node_modules/egg, baseDir: /egg-rpc-demo
+[ProtoRPCPlugin] found "org.eggjs.rpc.test.ProtoService" in proto file
+[ProtoRPCPlugin] save all proto info into "/egg-rpc-demo/run/proto.json"
+```
+
+#### 5. 调用服务
+
+通过 `ctx.proxy.proxyName` 来访问生成的 proxy 代码，proxyName 就是上面 proxy.js 配置的 api 键值对中的 key。例如：上面配置的 ProtoService，但是需要特别注意的是 proxyName 会自动转成小驼峰形式，所以就是 `ctx.proxy.protoService`。
+
+```js
+'use strict';
+
+const Controller = require('egg').Controller;
+
+class HomeController extends Controller {
+  async index() {
+    const { ctx } = this;
+    const res = await ctx.proxy.protoService.echoObj({
+      name: 'gxcsoccer',
+	    group: 'A',
+    });
+    ctx.body = res;
+  }
+}
+
+module.exports = HomeController;
+```
+
+和调用本地方法体验一模一样。
+
+
+### RPC 服务端
+
+该插件还可以暴露 SOFARPC 接口给其他应用调用
+
+#### 1. 定义接口
+
+同样以 protobuf 为例，将接口定义放置到 `${app_root}/proto` 目录下。
+```
+# ProtoService.proto
+syntax = "proto3";
+
+package org.eggjs.rpc.test;
+option java_multiple_files = true; // 可选
+option java_outer_classname = "ProtoServiceModels"; // 可选
+
+service ProtoService {
+    rpc echoObj (EchoRequest) returns (EchoResponse) {}
+}
+
+message EchoRequest {
+    string name = 1;
+    Group group = 2;
+}
+
+message EchoResponse {
+    int32 code = 1;
+    string message = 2;
+}
+
+enum Group {
+    A = 0;
+    B = 1;
+}
+```
+
+#### 2. 全局配置
+
+在 `${app_root}/config/config.${env}.js` 做一些配置
+
+```js
+module.exports = {
+	rpc: {
+    server: {
+      namespace: 'org.eggjs.rpc.test',
+    },
+	},
+},
+```
+
+- `namespace`(必选): 接口的命名空间，所有的暴露的接口默认都在该命名空间下
+- `selfPublish`(可选): 是否每个 worker 进程独立暴露服务。nodejs 多进程模式下，如果多个进程共享一个端口，在 RPC 这种场景可能造成负载不均，所以 selfPublish 默认为 true，代表每个进程独立监听端口和发布服务
+- `port`(可选): 服务监听的端口（注意：在 selfPublish=true 时，监听的端口是基于这个配置生成的）
+- `maxIdleTime`(可选): 客户端连接如果在该配置时长内没有任何流量，则主动断开连接
+- `responseTimeout`(可选): 服务端建议的超时时长，具体的超时还是以客户端配置为准
+- `codecType`(可选): 推荐的序列化方式，默认为 protobuf
+
+#### 3. 接口实现
+
+在 `${app_root}/app/rpc` 目录下放置接口的具体实现代码
+```js
+// ${app_root}/app/rpc/ProtoService.js
+exports.echoObj = async function(req) {
+  return {
+    code: 200,
+    message: 'hello ' + req.name + ', you are in ' + req.group,
+  };
+};
+```
+
+#### 4. 测试 RPC 接口
+
+在单元测试中，我们可以通过 `app.rpcRequest` 接口来方便的测试我们自己暴露的 RPC 服务，例如：
+
+```js
+'use strict';
+
+const mm = require('egg-mock');
+
+describe('test/index.test.js', () => {
+  let app;
+  before(async function() {
+    app = mm.app({
+      baseDir: 'apps/rpcserver',
+    });
+    await app.ready();
+  });
+  after(async function() {
+    await app.close();
+  });
+
+  it('should invoke HelloService', done => {
+    app.rpcRequest('org.eggjs.rpc.test.HelloService')
+      .invoke('hello')
+      .send([ 'gxcsoccer' ])
+      .expect('hello gxcsoccer', done);
+  });
+});
+```
+
+详细 `app.rpcRequest` 的 api 可以参考：[单元测试 RPC 服务的方法](https://github.com/eggjs/egg-sofa-rpc/wiki/%E5%8D%95%E5%85%83%E6%B5%8B%E8%AF%95-RPC-%E6%9C%8D%E5%8A%A1%E7%9A%84%E6%96%B9%E6%B3%95)
+
+
+## 相关文档
+
+- [《聊聊 Nodejs RPC（一）》](https://github.com/alipay/sofa-rpc-node/wiki/%E8%81%8A%E8%81%8A-Nodejs-RPC%EF%BC%88%E4%B8%80%EF%BC%89)
+- [Eggjs 和 SOFA 的跨语言互调](https://github.com/eggjs/egg-sofa-rpc/wiki/Eggjs-%E5%92%8C-SOFA-%E7%9A%84%E8%B7%A8%E8%AF%AD%E8%A8%80%E4%BA%92%E8%B0%83)
+- [自定义服务发现实现](https://github.com/eggjs/egg-sofa-rpc/wiki/%E8%87%AA%E5%AE%9A%E4%B9%89%E6%9C%8D%E5%8A%A1%E5%8F%91%E7%8E%B0%E5%AE%9E%E7%8E%B0)
+- [RPC 代理（Proxy）配置](https://github.com/eggjs/egg-sofa-rpc/wiki/RPC-%E4%BB%A3%E7%90%86%EF%BC%88Proxy%EF%BC%89%E9%85%8D%E7%BD%AE)
+- [单元测试 RPC 服务的方法](https://github.com/eggjs/egg-sofa-rpc/wiki/%E5%8D%95%E5%85%83%E6%B5%8B%E8%AF%95-RPC-%E6%9C%8D%E5%8A%A1%E7%9A%84%E6%96%B9%E6%B3%95)
+
+## 贡献代码
+
+请告知我们可以为你做些什么，不过在此之前，请检查一下是否有[已经存在的Bug或者意见](https://github.com/eggjs/egg/issues)。
+
+如果你是一个代码贡献者，请参考[代码贡献规范](https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md)。
+
+## 开源协议
+
+[MIT](LICENSE)

--- a/agent.js
+++ b/agent.js
@@ -1,0 +1,10 @@
+'use strict';
+
+module.exports = agent => {
+  agent.beforeStart(async function() {
+    // 可能不需要 rpcRegistry，比如直连的情况
+    if (!agent.rpcRegistry) return;
+
+    await agent.rpcRegistry.ready();
+  });
+};

--- a/app.js
+++ b/app.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const path = require('path');
+
+module.exports = app => {
+  // 载入到 app.proxyClasses
+  app.loader.loadToContext(path.join(app.config.baseDir, 'app/proxy'), 'proxy', {
+    call: true,
+    caseStyle: 'lower',
+    fieldClass: 'proxyClasses',
+  });
+
+  const paths = app.loader.getLoadUnits().map(unit => path.join(unit.path, 'app/rpc'));
+  app.loader.loadToApp(paths, 'rpcServices', {
+    call: true,
+    caseStyle: 'camel', // 首字母不变
+  });
+
+  // 如果有 app/rpc 服务，则自动启动 server
+  if (app.config.rpc.server.autoServe && Object.keys(app.rpcServices).length) {
+    app.beforeStart(async function() {
+      await app.rpcServer.start();
+    });
+  }
+};

--- a/app/extend/agent.js
+++ b/app/extend/agent.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const _rpcRegistry = Symbol.for('egg#rpcRegistry');
+
+module.exports = {
+  get rpcRegistry() {
+    if (!this[_rpcRegistry]) {
+      const options = this.config.rpc.registry;
+      if (!options) return null;
+      const registryClass = this.config.rpc.registryClass;
+      this[_rpcRegistry] = new registryClass(Object.assign({
+        logger: this.coreLogger,
+        cluster: this.cluster,
+      }, options));
+      this[_rpcRegistry].on('error', err => { this.coreLogger.error(err); });
+      this.beforeClose(async () => {
+        await this[_rpcRegistry].close();
+      });
+    }
+    return this[_rpcRegistry];
+  },
+};

--- a/app/extend/application.js
+++ b/app/extend/application.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const EggRpcClient = require('../../lib/client');
+const EggRpcServer = require('../../lib/server');
+const ProxyBase = require('../../lib/base_proxy');
+
+// Symbols
+const _rpcRegistry = Symbol.for('egg#rpcRegistry');
+const _rpcClient = Symbol.for('egg#rpcClient');
+const _rpcServer = Symbol.for('egg#rpcServer');
+
+module.exports = {
+  get Proxy() {
+    return ProxyBase;
+  },
+  get rpcRegistry() {
+    if (!this[_rpcRegistry]) {
+      const options = this.config.rpc.registry;
+      if (!options) return null;
+
+      const registryClass = this.config.rpc.registryClass;
+      this[_rpcRegistry] = new registryClass(Object.assign({
+        logger: this.coreLogger,
+        cluster: this.cluster,
+      }, options));
+      this[_rpcRegistry].on('error', err => { this.coreLogger.error(err); });
+      this.beforeClose(async () => {
+        await this[_rpcRegistry].close();
+      });
+    }
+    return this[_rpcRegistry];
+  },
+  get rpcClient() {
+    if (!this[_rpcClient]) {
+      this[_rpcClient] = new EggRpcClient(this);
+      this[_rpcClient].on('error', err => { this.coreLogger.error(err); });
+      this.beforeClose(async () => {
+        await this[_rpcClient].close();
+      });
+    }
+    return this[_rpcClient];
+  },
+  get rpcServer() {
+    if (!this[_rpcServer]) {
+      this[_rpcServer] = new EggRpcServer(this);
+      this[_rpcServer].on('error', err => { this.coreLogger.error(err); });
+      this.beforeClose(async () => {
+        await this[_rpcServer].close();
+        this.coreLogger.info('[egg-rpc] rpc server is closed');
+      });
+    }
+    return this[_rpcServer];
+  },
+};

--- a/app/extend/application.unittest.js
+++ b/app/extend/application.unittest.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const request = require('sofa-rpc-node').test;
+
+module.exports = {
+  /**
+   * rpc 服务测试 helper
+   * ```js
+   * app.rpcRequest('helloService')
+   *   .invoke('plus')
+   *   .send([ 1, 2 ])
+   *   .type('number')
+   *   .expect(3, done);
+   * ```
+   * @param {String} serviceName - rpc 服务全称
+   * @return {Request} req
+   */
+  rpcRequest(serviceName) {
+    // 自动填充 namespace
+    if (this.config.rpc && this.config.rpc.server &&
+      this.config.rpc.server.namespace &&
+      !serviceName.startsWith('com.') &&
+      !serviceName.startsWith(this.config.rpc.server.namespace)) {
+      serviceName = `${this.config.rpc.server.namespace}.${serviceName}`;
+    }
+    return request(this.rpcServer).service(serviceName);
+  },
+};

--- a/config/config.default.js
+++ b/config/config.default.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const antpb = require('antpb');
+const protocol = require('sofa-bolt-node');
+const { ZookeeperRegistry } = require('sofa-rpc-node').registry;
+
+module.exports = appInfo => {
+  const protoPath = path.join(appInfo.baseDir, 'run/proto.json');
+  // 加载 proto
+  if (fs.existsSync(protoPath)) {
+    const proto = antpb.fromJSON(require(protoPath));
+    protocol.setOptions({ proto });
+  }
+
+  return {
+    rpc: {
+      registryClass: ZookeeperRegistry,
+      registry: null,
+      client: {
+        protocol,
+        responseTimeout: 3000,
+      },
+      server: {
+        protocol,
+        port: 12200,
+        idleTime: 5000,
+        killTimeout: 30000,
+        maxIdleTime: 90 * 1000,
+        responseTimeout: 3000,
+        codecType: 'protobuf',
+        selfPublish: true,
+        // 下面配置针对新的 rpc 服务发布方式
+        namespace: null,
+        version: '1.0',
+        group: 'SOFA',
+        uniqueId: null,
+        autoServe: true, // 如果发现有暴露服务，则自定启动 server
+      },
+    },
+  };
+};

--- a/lib/base_proxy.js
+++ b/lib/base_proxy.js
@@ -1,0 +1,39 @@
+/**
+ * BaseProxy, proxy 基类，封装 proxy 的通用逻辑
+ */
+
+'use strict';
+
+/**
+ * Proxy 基类，封装 proxy 的通用逻辑。
+ * 你可以通过继承此基类来编写 proxy
+ * @example
+ * ```js
+ * // app/proxy/user.js
+ * module.exports = function(app) {
+ *  return class UserProxy extends app.Proxy {
+ *    constructor(ctx) {
+ *      super(ctx);
+ *    }
+ *
+ *    // 定义方法
+ *  }
+ * };
+ */
+class Proxy {
+
+  /**
+   * Constructs the object.
+   *
+   * @param      {Context}  ctx       The context
+   * @param      {Consumer}  consumer  The consumer
+   * @constructor
+   */
+  constructor(ctx, consumer) {
+    this.ctx = ctx;
+    this.app = ctx.app;
+    this._consumer = consumer;
+  }
+}
+
+module.exports = Proxy;

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const assert = require('assert');
+const { RpcClient } = require('sofa-rpc-node').client;
+
+class EggRpcClient extends RpcClient {
+  constructor(app) {
+    const globalConfig = app.config.rpc && app.config.rpc.client;
+    super(Object.assign({
+      logger: app.coreLogger,
+      registry: app.rpcRegistry,
+    }, globalConfig));
+    this.app = app;
+    this.globalConfig = globalConfig;
+  }
+
+  createConsumer(options, consumerClass) {
+    const targetAppName = options.targetAppName;
+    assert(targetAppName, '[egg-rpc:client] createConsumer(options, consumerClass) options must config targetAppName');
+
+    const globalConfig = this.globalConfig;
+    // 支持 `app.config['targetAppName.rpc.service.options'] = { ... }`
+    options = Object.assign({ app: this.app }, globalConfig, globalConfig[targetAppName + '.rpc.service.options'], options);
+
+    // 读取 responseTimeout 优先级如下
+    // 1. 通过 config 的 ${targetAppName}.rpc.service.timeout 读取
+    // 2. 尝试从 consumer 配置 responseTimeout 读取
+    // 3. 尝试从 app.config.rpc.responseTimeout 读取
+    // 4. 默认 5000ms 超时
+    const timeoutKey = targetAppName + '.rpc.service.timeout';
+    const timeout = options[timeoutKey];
+    options.responseTimeout = Number(timeout) || options.responseTimeout || this.options.responseTimeout || 5000;
+
+    // 硬负载
+    if (!options.serverHost) {
+      const testUrl = options[targetAppName + '.rpc.service.url'];
+      const proxyName = options.proxyName;
+      const proxyTestUrl = proxyName ? options['proxy.' + proxyName + '.rpc.service.url'] : null;
+      options.serverHost = proxyTestUrl || testUrl;
+    }
+    return super.createConsumer(options, consumerClass);
+  }
+}
+
+module.exports = EggRpcClient;

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,0 +1,143 @@
+'use strict';
+
+const http = require('http');
+const is = require('is-type-of');
+const assert = require('assert');
+const cluster = require('cluster');
+const { RpcServer } = require('sofa-rpc-node').server;
+
+class EggRpcServer extends RpcServer {
+  constructor(app) {
+    const options = app.config.rpc && app.config.rpc.server;
+    const selfPublish = options.selfPublish && cluster.isWorker;
+
+    let registry = app.rpcRegistry;
+    if (selfPublish && app.rpcRegistry) {
+      registry = new app.rpcRegistry.DataClient(app.rpcRegistry.options);
+    }
+    super(Object.assign({
+      appName: app.name,
+      // 如果是 selfPublish 单独创建 registry 连接来发布服务
+      registry,
+      logger: app.coreLogger,
+    }, options));
+
+    this.app = app;
+    this.selfPublish = selfPublish;
+
+    // 等 app 已经 ready 后才向注册中心注册服务
+    app.ready(err => {
+      if (!err) {
+        this.load();
+        this.publish();
+        this.logger.info('[egg-rpc#server] publish all rpc services after app ready');
+      }
+    });
+  }
+
+  get listenPorts() {
+    let port = this.options.port;
+    if (this.selfPublish) {
+      port = port + cluster.worker.id;
+      this.publishPort = port;
+      return [ port, this.options.port ];
+    }
+    return [ port ];
+  }
+
+  load() {
+    const { app } = this;
+    const { namespace } = app.config.rpc.server;
+
+    // load apiMeta
+    for (const name in app.rpcServices) {
+      let delegate = app.rpcServices[name];
+
+      const interfaceName = `${namespace}.${name}`;
+      const service = Object.assign({ interfaceName }, app.config.rpc.server);
+      if (delegate.interfaceName || delegate.namespace) {
+        service.interfaceName = delegate.interfaceName ? delegate.interfaceName : `${delegate.namespace}.${name}`;
+        service.uniqueId = delegate.uniqueId || '';
+        service.version = delegate.version || service.version;
+        service.group = delegate.group || service.group;
+      }
+
+      if (is.class(delegate)) {
+        delegate = wrap(app, delegate);
+      } else {
+        for (const key of Object.keys(delegate)) {
+          delegate[key] = app.toAsyncFunction(delegate[key]);
+        }
+      }
+      this.addService(service, delegate);
+    }
+  }
+
+  /**
+   * @param {HSFRequest} req
+   *   - @param {Object} requestProps
+   *   - @param {Number} packetId
+   *   - @param {String} packetType
+   *   - @param {String} methodName
+   *   - @param {String} serverSignature interfaceName
+   *   - @param {Array} args
+   * @param {HSFResponse} res
+   *   - @param {Function} send
+   * @return {Context} ctx
+   */
+  createContext(req, res) {
+    assert(req && req.data, '[egg-rpc#server] req && req.data is required');
+    const reqData = req.data;
+    const { serverSignature, methodName, args } = reqData;
+    const httpReq = {
+      method: 'RPC',
+      url: '/rpc/' + serverSignature + '/' + methodName,
+      headers: {},
+      socket: res.socket,
+    };
+    const ctx = this.app.createContext(httpReq, new http.ServerResponse(httpReq));
+    ctx.params = args;
+    return ctx;
+  }
+
+  addService(service, delegate) {
+    assert(service && delegate, '[egg-rpc#server] addService(service, delegate) service & delegate is required');
+    if (is.string(service)) {
+      service = {
+        id: service,
+        group: this.options.group,
+      };
+    }
+    // 将 app 传入
+    service.app = this.app;
+    return super.addService(service, delegate);
+  }
+
+  _handleUncaughtError() {
+    if (this.selfPublish) {
+      this.unPublish();
+      this.logger.warn('[egg-rpc#server] unPublish all rpc services for uncaughtException in this process %s', process.pid);
+    } else {
+      this.logger.warn('[egg-rpc#server] rpc server is down, cause by uncaughtException in this process %s', process.pid);
+    }
+  }
+}
+
+function wrap(app, Class) {
+  const proto = Class.prototype;
+  const result = {};
+  for (const key of Object.getOwnPropertyNames(proto)) {
+    if (!is.asyncFunction(proto[key]) && !is.generatorFunction(proto[key])) {
+      continue;
+    }
+
+    proto[key] = app.toAsyncFunction(proto[key]);
+    result[key] = async function(...args) {
+      const instance = new Class(this);
+      return await instance[key](...args);
+    };
+  }
+  return result;
+}
+
+module.exports = EggRpcServer;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "egg-rpc-base",
+  "version": "1.0.0",
+  "description": "rpc base plugin for eggjs",
+  "eggPlugin": {
+    "name": "rpc"
+  },
+  "keywords": [
+    "egg",
+    "eggPlugin",
+    "egg-plugin"
+  ],
+  "dependencies": {
+    "antpb": "^1.0.0",
+    "is-type-of": "^1.2.1",
+    "sofa-bolt-node": "^1.0.2",
+    "sofa-rpc-node": "^1.5.3"
+  },
+  "devDependencies": {
+    "autod": "^3.0.1",
+    "autod-egg": "^1.1.0",
+    "egg": "^2.12.0",
+    "egg-bin": "^4.9.0",
+    "egg-mock": "^3.20.1",
+    "egg-rpc-generator": "^1.0.0",
+    "eslint": "^5.8.0",
+    "eslint-config-egg": "^7.1.0",
+    "mz-modules": "^2.1.0",
+    "webstorm-disable-index": "^1.2.0"
+  },
+  "engines": {
+    "node": ">=8.0.0"
+  },
+  "scripts": {
+    "autod": "autod",
+    "lint": "eslint . --ext .js",
+    "cov": "sh test/init.sh && TEST_TIMEOUT=20000 egg-bin cov",
+    "test": "npm run lint && npm run test-local",
+    "test-local": "sh test/init.sh && egg-bin test",
+    "pkgfiles": "egg-bin pkgfiles --check",
+    "ci": "npm run autod -- --check && npm run pkgfiles && npm run lint && npm run cov",
+    "contributors": "contributors -f plain -o AUTHORS"
+  },
+  "files": [
+    "app",
+    "config",
+    "lib",
+    "app.js",
+    "agent.js"
+  ],
+  "ci": {
+    "version": "8, 10"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/eggjs/egg-rpc.git"
+  },
+  "bugs": {
+    "url": "https://github.com/eggjs/egg/issues"
+  },
+  "homepage": "https://github.com/eggjs/egg-rpc#readme",
+  "author": "gxcsoccer <gxcsoccer@126.com>",
+  "license": "MIT"
+}

--- a/test/custom_registry.test.js
+++ b/test/custom_registry.test.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const path = require('path');
+const mm = require('egg-mock');
+const assert = require('assert');
+const sleep = require('mz-modules/sleep');
+const rimraf = require('mz-modules/rimraf');
+
+describe('test/custom_registry.test.js', () => {
+
+  async function cleanDir() {
+    await Promise.all([
+      rimraf(path.join(__dirname, 'fixtures/apps/custom-registry/app/proxy')),
+      rimraf(path.join(__dirname, 'fixtures/apps/custom-registry/logs')),
+      rimraf(path.join(__dirname, 'fixtures/apps/custom-registry/run')),
+    ]);
+  }
+
+  let app;
+  before(async function() {
+    app = mm.app({
+      baseDir: 'apps/custom-registry',
+    });
+    await app.ready();
+    await sleep(1000);
+  });
+  after(async function() {
+    await app.close();
+    await cleanDir();
+  });
+
+  it('should invoke ok', async function() {
+    const ctx = app.createAnonymousContext();
+    const res = await ctx.proxy.protoService.echoObj({
+      name: 'gxcsoccer',
+      group: 'B',
+    });
+    console.log(res);
+    assert.deepEqual(res, {
+      code: 200,
+      message: 'hello gxcsoccer from Node.js',
+    });
+  });
+
+  it('should app.rpcRequest ok', done => {
+    app.rpcRequest('com.alipay.sofa.rpc.test.ProtoService')
+      .invoke('echoObj')
+      .send([{
+        name: 'gxcsoccer',
+        group: 'B',
+      }])
+      .expect({
+        code: 200,
+        message: 'hello gxcsoccer from Node.js',
+      }, done);
+  });
+});

--- a/test/fixtures/apps/custom-registry/app/router.js
+++ b/test/fixtures/apps/custom-registry/app/router.js
@@ -1,0 +1,10 @@
+'use strict';
+
+module.exports = app => {
+  app.get('/', async function(ctx) {
+    ctx.body = await ctx.proxy.protoService.echoObj({
+      name: 'zongyu',
+      group: 'B',
+    });
+  });
+};

--- a/test/fixtures/apps/custom-registry/app/rpc/ProtoService.js
+++ b/test/fixtures/apps/custom-registry/app/rpc/ProtoService.js
@@ -1,0 +1,12 @@
+'use strict';
+
+exports.echoObj = async function(req) {
+  return {
+    code: 200,
+    message: 'hello ' + req.name + ' from Node.js',
+  };
+};
+
+exports.interfaceName = 'com.alipay.sofa.rpc.test.ProtoService';
+exports.version = '1.0';
+exports.group = 'SOFA';

--- a/test/fixtures/apps/custom-registry/config/config.default.js
+++ b/test/fixtures/apps/custom-registry/config/config.default.js
@@ -1,0 +1,8 @@
+'use strict';
+
+exports.rpc = {
+  registryClass: require('../lib/registry'),
+  registry: {},
+};
+
+exports.keys = '123456';

--- a/test/fixtures/apps/custom-registry/config/proxy.js
+++ b/test/fixtures/apps/custom-registry/config/proxy.js
@@ -1,0 +1,10 @@
+'use strict';
+
+module.exports = {
+  services: [{
+    appName: 'sofarpc',
+    api: {
+      ProtoService: 'com.alipay.sofa.rpc.test.ProtoService',
+    },
+  }],
+};

--- a/test/fixtures/apps/custom-registry/lib/client.js
+++ b/test/fixtures/apps/custom-registry/lib/client.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const Base = require('sdk-base');
+
+class SimpleRegistry extends Base {
+  constructor(options) {
+    super(options);
+    this.ready(true);
+  }
+
+  async register() {}
+
+  async unRegister() {}
+
+  subscribe(config, listener) {
+    setImmediate(() => {
+      listener([
+        'bolt://127.0.0.1:12200',
+      ]);
+    });
+  }
+
+  unSubscribe() {}
+
+  close() {
+    return Promise.resolve()
+  }
+}
+
+module.exports = SimpleRegistry;

--- a/test/fixtures/apps/custom-registry/lib/registry.js
+++ b/test/fixtures/apps/custom-registry/lib/registry.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const RegistryBase = require('sofa-rpc-node/lib/registry/base');
+const DataClient = require('./client');
+
+class CustomeRegistry extends RegistryBase {
+  get DataClient() {
+    return DataClient;
+  }
+}
+
+module.exports = CustomeRegistry

--- a/test/fixtures/apps/custom-registry/package.json
+++ b/test/fixtures/apps/custom-registry/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "custom-registry"
+}

--- a/test/fixtures/apps/custom-registry/proto/ProtoService.proto
+++ b/test/fixtures/apps/custom-registry/proto/ProtoService.proto
@@ -1,0 +1,25 @@
+syntax = "proto3";
+
+package com.alipay.sofa.rpc.test;
+
+// 可选
+option java_multiple_files = false;
+
+service ProtoService {
+  rpc echoObj (EchoRequest) returns (EchoResponse) {}
+}
+
+message EchoRequest {
+  string name = 1;
+  Group group = 2;
+}
+
+message EchoResponse {
+  int32 code = 1;
+  string message = 2;
+}
+
+enum Group {
+  A = 0;
+  B = 1;
+}

--- a/test/fixtures/apps/hardload/app/proxy/ProtoService.js
+++ b/test/fixtures/apps/hardload/app/proxy/ProtoService.js
@@ -1,0 +1,41 @@
+// Don't modified this file, it's auto created by egg-rpc-generator
+
+'use strict';
+
+const path = require('path');
+
+/* eslint-disable */
+/* istanbul ignore next */
+module.exports = app => {
+  const consumer = app.rpcClient.createConsumer({
+    interfaceName: 'com.alipay.sofa.rpc.test.ProtoService',
+    targetAppName: 'sofarpc',
+    version: '1.0',
+    group: 'SOFA',
+    proxyName: 'ProtoService',
+  });
+
+  if (!consumer) {
+    // `app.config['sofarpc.rpc.service.enable'] = false` will disable this consumer
+    return;
+  }
+
+  app.beforeStart(async() => {
+    await consumer.ready();
+  });
+
+  class ProtoService extends app.Proxy {
+    constructor(ctx) {
+      super(ctx, consumer);
+    }
+
+    async echoObj(req) {
+      return await consumer.invoke('echoObj', [ req ], { 
+        ctx: this.ctx,
+      });
+    }
+  }
+
+  return ProtoService;
+};
+/* eslint-enable */

--- a/test/fixtures/apps/hardload/app/router.js
+++ b/test/fixtures/apps/hardload/app/router.js
@@ -1,0 +1,10 @@
+'use strict';
+
+module.exports = app => {
+  app.get('/', async function(ctx) {
+    ctx.body = await ctx.proxy.protoService.echoObj({
+      name: 'zongyu',
+      group: 'B',
+    });
+  });
+};

--- a/test/fixtures/apps/hardload/app/rpc/ProtoService.js
+++ b/test/fixtures/apps/hardload/app/rpc/ProtoService.js
@@ -1,0 +1,8 @@
+'use strict';
+
+exports.echoObj = async function(req) {
+  return {
+    code: 200,
+    message: 'hello ' + req.name + ' from Node.js',
+  };
+};

--- a/test/fixtures/apps/hardload/config/config.default.js
+++ b/test/fixtures/apps/hardload/config/config.default.js
@@ -1,0 +1,13 @@
+'use strict';
+
+exports.rpc = {
+  client: {
+    ['sofarpc.rpc.service.url']: '127.0.0.1:12200',
+  },
+  server: {
+    // selfPublish: false,
+    namespace: 'com.alipay.sofa.rpc.test',
+  },
+};
+
+exports.keys = '123456';

--- a/test/fixtures/apps/hardload/config/proxy.js
+++ b/test/fixtures/apps/hardload/config/proxy.js
@@ -1,0 +1,10 @@
+'use strict';
+
+module.exports = {
+  services: [{
+    appName: 'sofarpc',
+    api: {
+      ProtoService: 'com.alipay.sofa.rpc.test.ProtoService',
+    },
+  }],
+};

--- a/test/fixtures/apps/hardload/package.json
+++ b/test/fixtures/apps/hardload/package.json
@@ -1,0 +1,3 @@
+{
+	"name": "hardload"
+}

--- a/test/fixtures/apps/hardload/proto/ProtoService.proto
+++ b/test/fixtures/apps/hardload/proto/ProtoService.proto
@@ -1,0 +1,25 @@
+syntax = "proto3";
+
+package com.alipay.sofa.rpc.test;
+
+// 可选
+option java_multiple_files = false;
+
+service ProtoService {
+  rpc echoObj (EchoRequest) returns (EchoResponse) {}
+}
+
+message EchoRequest {
+  string name = 1;
+  Group group = 2;
+}
+
+message EchoResponse {
+  int32 code = 1;
+  string message = 2;
+}
+
+enum Group {
+  A = 0;
+  B = 1;
+}

--- a/test/fixtures/apps/rpcserver/app/rpc/HelloService.js
+++ b/test/fixtures/apps/rpcserver/app/rpc/HelloService.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const sleep = require('mz-modules/sleep');
+
+module.exports = function(app) {
+  const exports = {};
+
+  exports.interfaceName = 'com.alipay.nodejs.HelloService';
+  exports.version = '1.0';
+  exports.group = 'SOFA';
+
+
+  exports.hello = function*(name) {
+    yield sleep(200);
+    return 'hello ' + name;
+  };
+
+  return exports;
+}

--- a/test/fixtures/apps/rpcserver/app/rpc/MathService.js
+++ b/test/fixtures/apps/rpcserver/app/rpc/MathService.js
@@ -1,0 +1,13 @@
+'use strict';
+
+class MathService {
+  constructor(ctx) {
+    this.ctx = ctx;
+  }
+
+  async plus(a, b) {
+    return a + b;
+  }
+}
+
+module.exports = MathService;

--- a/test/fixtures/apps/rpcserver/config/config.default.js
+++ b/test/fixtures/apps/rpcserver/config/config.default.js
@@ -1,0 +1,14 @@
+'use strict';
+
+exports.rpc = {
+  registry: {
+    address: '127.0.0.1:2181',
+  },
+  server: {
+    port: 12200,
+    codecType: 'hessian2',
+    selfPublish: true,
+    // 下面配置针对新的 rpc 服务发布方式
+    namespace: 'com.alipay.nodejs.rpc',
+  },
+};

--- a/test/fixtures/apps/rpcserver/package.json
+++ b/test/fixtures/apps/rpcserver/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "rpcserver"
+}

--- a/test/fixtures/apps/self-publish/app/rpc/HelloService.js
+++ b/test/fixtures/apps/self-publish/app/rpc/HelloService.js
@@ -1,0 +1,20 @@
+'use strict';
+
+/**
+ * 加法计数服务
+ * @hsf
+ * @public
+ * @param {Number} a - 被加数
+ * @param {Number} b - 加数
+ * @return {Number} 结果
+ */
+exports.plus = async function(a, b) {
+  return a + b;
+};
+
+exports.error = async function() {
+  setTimeout(() => {
+    throw new Error('uncaughtException');
+  }, 1000);
+  return 'ok';
+};

--- a/test/fixtures/apps/self-publish/config/config.default.js
+++ b/test/fixtures/apps/self-publish/config/config.default.js
@@ -1,0 +1,24 @@
+'use strict';
+
+exports.rpc = {
+  registry: {
+    address: '127.0.0.1:2181',
+  },
+  client: {
+    responseTimeout: 3000,
+  },
+  server: {
+    port: 12200 + Number(process.versions.node.split('.')[0]),
+    idleTime: 5000,
+    killTimeout: 30000,
+    maxIdleTime: 90 * 1000,
+    responseTimeout: 3000,
+    codecType: 'hessian2',
+    selfPublish: true,
+    // 下面配置针对新的 rpc 服务发布方式
+    namespace: 'com.alipay.nodejs.selfPublish',
+    version: '1.0',
+    group: 'SOFA',
+    uniqueId: null,
+  },
+};

--- a/test/fixtures/apps/self-publish/package.json
+++ b/test/fixtures/apps/self-publish/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "self-publish"
+}

--- a/test/fixtures/apps/sofarpc/app/rpc/ProtoService.js
+++ b/test/fixtures/apps/sofarpc/app/rpc/ProtoService.js
@@ -1,0 +1,9 @@
+'use strict';
+
+exports.echoObj = async function(req) {
+  req = req.toObject({ enums: String });
+  return {
+    code: 200,
+    message: 'hello ' + req.name + ', you are in ' + req.group,
+  };
+};

--- a/test/fixtures/apps/sofarpc/config/config.default.js
+++ b/test/fixtures/apps/sofarpc/config/config.default.js
@@ -1,0 +1,11 @@
+'use strict';
+
+exports.rpc = {
+  registry: {
+    address: '127.0.0.1:2181',
+  },
+  server: {
+    // selfPublish: false,
+    namespace: 'com.alipay.sofa.rpc.test',
+  },
+};

--- a/test/fixtures/apps/sofarpc/config/proxy.js
+++ b/test/fixtures/apps/sofarpc/config/proxy.js
@@ -1,0 +1,10 @@
+'use strict';
+
+module.exports = {
+  services: [{
+    appName: 'sofarpc',
+    api: {
+      ProtoService: 'com.alipay.sofa.rpc.test.ProtoService',
+    },
+  }],
+};

--- a/test/fixtures/apps/sofarpc/package.json
+++ b/test/fixtures/apps/sofarpc/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "sofarpc"
+}

--- a/test/fixtures/apps/sofarpc/proto/ProtoService.proto
+++ b/test/fixtures/apps/sofarpc/proto/ProtoService.proto
@@ -1,0 +1,25 @@
+syntax = "proto3";
+
+package com.alipay.sofa.rpc.test;
+
+// 可选
+option java_multiple_files = false;
+
+service ProtoService {
+  rpc echoObj (EchoRequest) returns (EchoResponse) {}
+}
+
+message EchoRequest {
+  string name = 1;
+  Group group = 2;
+}
+
+message EchoResponse {
+  int32 code = 1;
+  string message = 2;
+}
+
+enum Group {
+  A = 0;
+  B = 1;
+}

--- a/test/hardload.test.js
+++ b/test/hardload.test.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const mm = require('egg-mock');
+
+describe('test/hardload.test.js', () => {
+  let app;
+  before(async function() {
+    app = mm.app({
+      baseDir: 'apps/hardload',
+    });
+    await app.ready();
+  });
+  after(async function() {
+    await app.close();
+  });
+  afterEach(mm.restore);
+
+  it('should invoke with serverHost', async function() {
+    await app.httpRequest()
+      .get('/')
+      .expect({
+        code: 200,
+        message: 'hello zongyu from Node.js',
+      });
+  });
+});

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const path = require('path');
+const mm = require('egg-mock');
+const assert = require('assert');
+const sleep = require('mz-modules/sleep');
+const rimraf = require('mz-modules/rimraf');
+
+describe('test/index.test.js', () => {
+
+  async function cleanDir() {
+    await Promise.all([
+      rimraf(path.join(__dirname, 'fixtures/apps/sofarpc/app/proxy')),
+      rimraf(path.join(__dirname, 'fixtures/apps/sofarpc/logs')),
+      rimraf(path.join(__dirname, 'fixtures/apps/sofarpc/run')),
+    ]);
+  }
+
+  let app;
+  before(async function() {
+    app = mm.app({
+      baseDir: 'apps/sofarpc',
+    });
+    await app.ready();
+    await sleep(1000);
+  });
+  after(async function() {
+    await app.close();
+    await cleanDir();
+  });
+
+  it('should invoke ok', async function() {
+    const ctx = app.createAnonymousContext();
+    const res = await ctx.proxy.protoService.echoObj({
+      name: 'gxcsoccer',
+      group: 'B',
+    });
+    console.log(res);
+    assert.deepEqual(res, {
+      code: 200,
+      message: 'hello gxcsoccer, you are in B',
+    });
+  });
+
+  it('should app.rpcRequest ok', done => {
+    app.rpcRequest('ProtoService')
+      .invoke('echoObj')
+      .send([{
+        name: 'gxcsoccer',
+        group: 'B',
+      }])
+      .expect({
+        code: 200,
+        message: 'hello gxcsoccer, you are in B',
+      }, done);
+  });
+});

--- a/test/init.sh
+++ b/test/init.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+GEN=${PWD}/node_modules/.bin/egg-rpc-generator
+
+# test dir
+
+DIR=${PWD}/test/fixtures/apps
+NAMES="sofarpc hardload custom-registry"
+
+for NAME in $NAMES
+do
+  echo "Create ${DIR}/${NAME} proxy"
+  $GEN -b ${DIR}/${NAME}
+  echo "------------------------------------------------"
+done
+
+echo "All done"

--- a/test/self_publish.test.js
+++ b/test/self_publish.test.js
@@ -1,0 +1,131 @@
+'use strict';
+
+const mm = require('egg-mock');
+const assert = require('assert');
+const cluster = require('cluster');
+const sleep = require('mz-modules/sleep');
+const { RpcClient } = require('sofa-rpc-node').client;
+const { ZookeeperRegistry } = require('sofa-rpc-node').registry;
+
+const logger = console;
+
+describe('test/self_publish.test.js', () => {
+  let app;
+  let client;
+  let registry;
+  const interfaceName = 'com.alipay.nodejs.selfPublish.HelloService';
+  const port = 12200 + Number(process.versions.node.split('.')[0]);
+
+  describe('app.cluster()', () => {
+    before(async function() {
+      mm.env('production');
+      registry = new ZookeeperRegistry({
+        address: '127.0.0.1:2181',
+        logger,
+      });
+      app = mm.cluster({
+        baseDir: 'apps/self-publish',
+        workers: 4,
+      });
+      await app.ready();
+
+      client = new RpcClient({
+        registry,
+        logger,
+      });
+      await client.ready();
+
+      registry.subscribe({ interfaceName }, val => {
+        if (val.length === 4) {
+          registry.emit('init_address', val);
+        }
+      });
+      const addressList = await registry.await('init_address');
+      assert(addressList.every(url => url.port !== port));
+    });
+    afterEach(mm.restore);
+    after(async function() {
+      await app.close();
+      await registry.close();
+      await sleep(2000);
+    });
+
+    it('should publish self worker', async function() {
+      let count = 4;
+      let ret;
+      const consumer = client.createConsumer({ interfaceName });
+      await consumer.ready();
+      while (count--) {
+        ret = await consumer.invoke('plus', [ 1, 2 ]);
+        assert(ret === 3);
+      }
+
+      const directConsumer = client.createConsumer({
+        interfaceName,
+        serverHost: `127.0.0.1:${port}`,
+      });
+      await directConsumer.ready();
+      // 原始端口也需要监听
+      ret = await directConsumer.invoke('plus', [ 1, 2 ]);
+      assert(ret === 3);
+    });
+
+    it(`should app ready failed cause ${port} is used`, async function() {
+      mm(cluster, 'isWorker', true);
+      mm(cluster, 'worker', { id: 10 });
+      let app;
+      try {
+        app = mm.app({
+          baseDir: 'apps/self-publish',
+        });
+        await app.ready();
+        assert(false, 'should not run here');
+      } catch (err) {
+        assert(err.message.includes('listen EADDRINUSE'));
+      }
+      if (app) {
+        await app.close();
+      }
+    });
+
+    it('should publish again if app worker uncaughtException', async function() {
+      registry.subscribe({ interfaceName }, val => {
+        registry.emit('service_address', val);
+      });
+
+      let addressList = await registry.await('service_address');
+      assert(addressList.length === 4);
+
+      const consumer = client.createConsumer({ interfaceName });
+      [ addressList ] = await Promise.all([
+        registry.await('service_address'),
+        consumer.invoke('error', []),
+      ]);
+
+      assert(addressList.length === 3);
+      addressList = await registry.await('service_address');
+      assert(addressList.length === 4);
+
+      let count = 4;
+      let ret;
+      while (count--) {
+        ret = await consumer.invoke('plus', [ 1, 2 ]);
+        assert(ret === 3);
+      }
+    });
+  });
+
+  describe('app.mm()', () => {
+    it('start 防重入', async function() {
+      mm(cluster, 'isWorker', true);
+      mm(cluster, 'worker', { id: 1000 });
+      const app = mm.app({
+        baseDir: 'apps/self-publish',
+      });
+      await app.ready();
+      await app.rpcServer.start();
+
+      await app.close();
+    });
+  });
+});

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const mm = require('egg-mock');
+
+describe('test/index.test.js', () => {
+  let app;
+  before(async function() {
+    app = mm.app({
+      baseDir: 'apps/rpcserver',
+    });
+    await app.ready();
+  });
+  after(async function() {
+    await app.close();
+  });
+
+  it('should invoke HelloService', done => {
+    app.rpcRequest('com.alipay.nodejs.HelloService')
+      .invoke('hello')
+      .send([ 'gxcsoccer' ])
+      .expect('hello gxcsoccer', done);
+  });
+
+  it('should invoke MathService', done => {
+    app.rpcRequest('com.alipay.nodejs.rpc.MathService')
+      .invoke('plus')
+      .send([ 1, 2 ])
+      .expect(3, done);
+  });
+});


### PR DESCRIPTION
将这个 egg-rpc 作为所有 rpc 插件的基础，egg-sofa-rpc/egg-dubbo-rpc 在它的基础上配置和扩展

因为让 dubbo 依赖 sofa-rpc 是不太合理的